### PR TITLE
test: fix router tests

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -7,7 +7,6 @@ describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [RouterTestingModule, NavigationComponent],
-      declarations: [AppComponent],
     }).compileComponents();
   });
 

--- a/src/app/components/navigation/navigation.component.spec.ts
+++ b/src/app/components/navigation/navigation.component.spec.ts
@@ -1,6 +1,7 @@
+import { provideLocationMocks } from '@angular/common/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterLink, provideRouter } from '@angular/router';
+import { provideRouter, RouterLink } from '@angular/router';
 import { NavigationComponent } from './navigation.component';
 
 describe('NavigationComponent', () => {
@@ -10,7 +11,7 @@ describe('NavigationComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [NavigationComponent],
-      providers: [provideRouter([])],
+      providers: [provideRouter([]), provideLocationMocks()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(NavigationComponent);

--- a/src/app/guards/guards.spec.ts
+++ b/src/app/guards/guards.spec.ts
@@ -1,6 +1,7 @@
+import { provideLocationMocks } from '@angular/common/testing';
 import { Component } from '@angular/core';
-import { TestBed, fakeAsync } from '@angular/core/testing';
-import { Router, provideRouter } from '@angular/router';
+import { fakeAsync, TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
 import { RouterTestingHarness } from '@angular/router/testing';
 import { of } from 'rxjs';
 import { isLoggedGuardFn } from '.';
@@ -33,6 +34,7 @@ describe('Functional Guards', () => {
             component: NoAccessTestComponent,
           },
         ]),
+        provideLocationMocks(),
         // {
         //   provide: Router,
         //   useValue: mockRouter,

--- a/src/app/pages/products/product-detail/product-detail.component.spec.ts
+++ b/src/app/pages/products/product-detail/product-detail.component.spec.ts
@@ -1,8 +1,8 @@
 import { fakeAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import {
-  SpectacularFeatureHarness,
   createFeatureHarness,
+  SpectacularFeatureHarness,
 } from '@ngworker/spectacular';
 import { ProductsComponent } from '../products.component';
 import { ProductDetailComponent } from './product-detail.component';
@@ -34,7 +34,7 @@ describe('ProductDetailComponent', () => {
 
     // Act (get the active component)
     const component =
-      await harness.rootComponent.getActiveComponent<ProductDetailComponent>();
+      harness.rootComponent.getActiveComponent<ProductDetailComponent>();
 
     // Assert (check the productId)
     expect(component.productId.toString()).toBe('1');

--- a/src/app/pages/products/product-detail/product-detail.component.ts
+++ b/src/app/pages/products/product-detail/product-detail.component.ts
@@ -1,12 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { Component, inject } from '@angular/core';
-import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { ProductsService } from 'src/app/services/products.service';
 
 @Component({
   selector: 'app-product-detail',
   standalone: true,
-  imports: [CommonModule, RouterLink],
+  imports: [CommonModule],
   template: `
     <h2>Product Detail</h2>
     <p class="back-to-products">


### PR DESCRIPTION
## Refactors

- Remove unused `RouterLink` import from `ProductDetailComponent`

## Test

- Remove `AppComponent` from `declarations` as it is a standalone component
- Use `provideLocationMocks` in router tests
- Remove redundant `await` before `SpectacularAppComponent#getActiveComponent`